### PR TITLE
Update date property being shown in comments endpoints

### DIFF
--- a/SprintManager.Application/DTOs/CommentDTO.cs
+++ b/SprintManager.Application/DTOs/CommentDTO.cs
@@ -9,5 +9,6 @@
         public string UserName { get; set; }
         public string Text { get; set; }
         public DateTime CreationDate { get; set; }
+        public DateTime? UpdateDate { get; set; }
     }
 }

--- a/SprintManager.Domain.Tests/CommentTests.cs
+++ b/SprintManager.Domain.Tests/CommentTests.cs
@@ -18,6 +18,7 @@ namespace SprintManager.Domain.Tests
             Assert.Equal(userId, comment.UserId);
             Assert.Equal("Comment 1", comment.Text);
             Assert.Equal(DateTime.UtcNow.Date, comment.CreationDate.Date);
+            Assert.Null(comment.UpdateDate?.Date);
         }
 
         // Test text change
@@ -29,6 +30,7 @@ namespace SprintManager.Domain.Tests
             comment.SetText("Comment 2");
 
             Assert.Equal("Comment 2", comment.Text);
+            Assert.Equal(DateTime.UtcNow.Date, comment.UpdateDate?.Date);
         }
 
         // Test exception throwing when work item ID is null or empty

--- a/SprintManager.Domain/Entities/Comment.cs
+++ b/SprintManager.Domain/Entities/Comment.cs
@@ -9,6 +9,7 @@ namespace SprintManager.Domain.Entities
         public Guid UserId { get; private set; }
         public string Text { get; private set; }
         public DateTime CreationDate { get; private set; }
+        public DateTime? UpdateDate { get; private set; }
         public WorkItem? WorkItem { get; private set; }
         public User? User { get; private set; }
 
@@ -37,6 +38,7 @@ namespace SprintManager.Domain.Entities
             if (text.Length > 500) throw new SprintManagerTooLongException("Comment is too long.", 500, text.Length, nameof(text));
 
             Text = text;
+            UpdateDate = DateTime.UtcNow;
         }
     }
 }

--- a/SprintManager.Infrastructure/Configurations/CommentConfiguration.cs
+++ b/SprintManager.Infrastructure/Configurations/CommentConfiguration.cs
@@ -22,6 +22,8 @@ namespace SprintManager.Infrastructure.Configurations
 
             builder.Property(c => c.CreationDate)
                 .IsRequired();
+
+            builder.Property(c => c.UpdateDate);
         }
     }
 }

--- a/SprintManager.Infrastructure/Migrations/20250805150051_AddUpdateDateColumnToCommentsTable.Designer.cs
+++ b/SprintManager.Infrastructure/Migrations/20250805150051_AddUpdateDateColumnToCommentsTable.Designer.cs
@@ -12,8 +12,8 @@ using SprintManager.Infrastructure.Data;
 namespace SprintManager.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20250731150640_AddCommentsTable")]
-    partial class AddCommentsTable
+    [Migration("20250805150051_AddUpdateDateColumnToCommentsTable")]
+    partial class AddUpdateDateColumnToCommentsTable
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -38,6 +38,9 @@ namespace SprintManager.Infrastructure.Migrations
                         .IsRequired()
                         .HasMaxLength(500)
                         .HasColumnType("nvarchar(500)");
+
+                    b.Property<DateTime?>("UpdateDate")
+                        .HasColumnType("datetime2");
 
                     b.Property<Guid>("UserId")
                         .HasColumnType("uniqueidentifier");

--- a/SprintManager.Infrastructure/Migrations/20250805150051_AddUpdateDateColumnToCommentsTable.cs
+++ b/SprintManager.Infrastructure/Migrations/20250805150051_AddUpdateDateColumnToCommentsTable.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace SprintManager.Infrastructure.Migrations
 {
     /// <inheritdoc />
-    public partial class AddCommentsTable : Migration
+    public partial class AddUpdateDateColumnToCommentsTable : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -19,7 +19,8 @@ namespace SprintManager.Infrastructure.Migrations
                     WorkItemId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     Text = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: false),
-                    CreationDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    CreationDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdateDate = table.Column<DateTime>(type: "datetime2", nullable: true)
                 },
                 constraints: table =>
                 {

--- a/SprintManager.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/SprintManager.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -36,6 +36,9 @@ namespace SprintManager.Infrastructure.Migrations
                         .HasMaxLength(500)
                         .HasColumnType("nvarchar(500)");
 
+                    b.Property<DateTime?>("UpdateDate")
+                        .HasColumnType("datetime2");
+
                     b.Property<Guid>("UserId")
                         .HasColumnType("uniqueidentifier");
 


### PR DESCRIPTION
The "update date" is the date of the last time a comment was edited.

Changes made:

- Add "UpdateDate" property in "Comment" domain;
- Add "UpdateDate" column to "Comments" table in database;
- Show "UpdateDate" value in "Comments" endpoints if a comment was edited.

Results:

- "UpdateComment" endpoint

<img width="1058" height="932" alt="image" src="https://github.com/user-attachments/assets/81089642-7fd8-4f8a-b614-4a1f9cb591dc" />

<br />
<br />

- "GetAllComments" endpoint

<img width="1416" height="938" alt="image" src="https://github.com/user-attachments/assets/827db301-b3f7-4fc9-a3ff-1f9a24f1eb07" />