### PR TITLE
Comments endpoints logic changed

### DIFF
--- a/SprintManager.Application.Tests/AuthTests/LogoutHandlerTests.cs
+++ b/SprintManager.Application.Tests/AuthTests/LogoutHandlerTests.cs
@@ -51,6 +51,7 @@ namespace SprintManager.Application.Tests.AuthTests
                 .Verify(r => r.DeleteAllByUserIdAsync(userId), Times.Once);
         }
 
+        // Test exception throwing when user is not authenticated
         [Fact]
         public async Task VerifyUser_ThrowException_WhenAuthenticatedUserIsNotFound()
         {

--- a/SprintManager.Application.Tests/CommentTests/CreateCommentHandlerTests.cs
+++ b/SprintManager.Application.Tests/CommentTests/CreateCommentHandlerTests.cs
@@ -1,4 +1,8 @@
 ﻿using AutoMapper;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using SprintManager.Application.Commands.Comments;
 using SprintManager.Application.DTOs;
@@ -11,25 +15,55 @@ namespace SprintManager.Application.Tests.CommentTests
 {
     public class CreateCommentHandlerTests
     {
+        private readonly Mock<IHttpContextAccessor> _mockHttpContextAccessor;
         private readonly Mock<ICommentRepository> _mockCommentRepository;
         private readonly Mock<IWorkItemRepository> _mockWorkItemRepository;
-        private readonly Mock<IUserRepository> _mockUserRepository;
+        private readonly Mock<UserManager<User>> _mockUserManager;
         private readonly Mock<IMapper> _mockMapper;
         private readonly CreateCommentHandler _handler;
 
         public CreateCommentHandlerTests()
         {
+            // Create mocks for UserManager constructor's dependencies
+            var mockUserStore = new Mock<IUserStore<User>>();
+            var mockOptions = new Mock<IOptions<IdentityOptions>>();
+            var mockPasswordHasher = new Mock<IPasswordHasher<User>>();
+            var mockUserValidator = new List<IUserValidator<User>>
+            {
+                new Mock<IUserValidator<User>>().Object
+            };
+            var mockPasswordValidator = new List<IPasswordValidator<User>>
+            {
+                new Mock<IPasswordValidator<User>>().Object
+            };
+            var mockLookupNormalizer = new Mock<ILookupNormalizer>();
+            var mockErrors = new Mock<IdentityErrorDescriber>();
+            var mockServiceProvider = new Mock<IServiceProvider>();
+            var mockLogger = new Mock<ILogger<UserManager<User>>>();
+
             // Initialize mocks for each test
+            _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
             _mockCommentRepository = new Mock<ICommentRepository>();
             _mockWorkItemRepository = new Mock<IWorkItemRepository>();
-            _mockUserRepository = new Mock<IUserRepository>();
+            _mockUserManager = new Mock<UserManager<User>>(
+                mockUserStore.Object,
+                mockOptions.Object,
+                mockPasswordHasher.Object,
+                mockUserValidator,
+                mockPasswordValidator,
+                mockLookupNormalizer.Object,
+                mockErrors.Object,
+                mockServiceProvider.Object,
+                mockLogger.Object
+            );
             _mockMapper = new Mock<IMapper>();
 
             // Initialize handler injecting the mocks
             _handler = new CreateCommentHandler(
+                _mockHttpContextAccessor.Object,
                 _mockCommentRepository.Object, 
                 _mockWorkItemRepository.Object,
-                _mockUserRepository.Object,
+                _mockUserManager.Object,
                 _mockMapper.Object
             );
         }

--- a/SprintManager.Application.Tests/CommentTests/CreateCommentHandlerTests.cs
+++ b/SprintManager.Application.Tests/CommentTests/CreateCommentHandlerTests.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
-using SprintManager.Application.Commands.Auth;
 using SprintManager.Application.Commands.Comments;
 using SprintManager.Application.DTOs;
 using SprintManager.Application.Handlers.Comments;

--- a/SprintManager.Application.Tests/CommentTests/CreateCommentHandlerTests.cs
+++ b/SprintManager.Application.Tests/CommentTests/CreateCommentHandlerTests.cs
@@ -4,12 +4,14 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
+using SprintManager.Application.Commands.Auth;
 using SprintManager.Application.Commands.Comments;
 using SprintManager.Application.DTOs;
 using SprintManager.Application.Handlers.Comments;
 using SprintManager.Application.Interfaces;
 using SprintManager.Domain.Entities;
 using SprintManager.Exceptions.ExceptionsBase;
+using System.Security.Claims;
 
 namespace SprintManager.Application.Tests.CommentTests
 {
@@ -75,11 +77,12 @@ namespace SprintManager.Application.Tests.CommentTests
             var command = new CreateCommentCommand
             {
                 WorkItemId = Guid.NewGuid(),
-                UserId = Guid.NewGuid(),
                 Text = "Test comment"
             };
 
-            var comment = new Comment(command.WorkItemId, command.UserId, command.Text);
+            var userId = Guid.NewGuid();
+
+            var comment = new Comment(command.WorkItemId, userId, command.Text);
             var commentDTO = new CommentDTO
             {
                 Id = comment.Id,
@@ -89,9 +92,13 @@ namespace SprintManager.Application.Tests.CommentTests
                 CreationDate = comment.CreationDate
             };
 
-            // Repository's mock configuration
+            _mockHttpContextAccessor
+                .Setup(a => a.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier))
+                .Returns(new Claim(ClaimTypes.NameIdentifier, userId.ToString()));
+            
             _mockWorkItemRepository.Setup(r => r.GetByIdAsync(command.WorkItemId)).ReturnsAsync(new WorkItem());
-            _mockUserRepository.Setup(r => r.GetByIdAsync(command.UserId)).ReturnsAsync(new User());
+            _mockUserManager.Setup(r => r.FindByIdAsync(userId.ToString())).ReturnsAsync(new User());
             _mockCommentRepository.Setup(r => r.AddAsync(It.IsAny<Comment>())).Callback<Comment>(c => comment = c);
 
             // Mapper's mock configuration
@@ -105,15 +112,47 @@ namespace SprintManager.Application.Tests.CommentTests
             Assert.Equal(commentDTO.Text, result.Text);
             Assert.Equal(commentDTO.CreationDate, result.CreationDate);
 
+            // Ensure HttpContextAccesor was used exactly once.
+            _mockHttpContextAccessor
+                .Verify(a => a.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier), Times.Once);
+
             // Ensure GetByIdAsync was called exactly once.
             _mockWorkItemRepository.Verify(r => r.GetByIdAsync(command.WorkItemId), Times.Once);
-            _mockUserRepository.Verify(r => r.GetByIdAsync(command.UserId), Times.Once);
+
+            // Ensure FindByIdAsync was called exactly once.
+            _mockUserManager.Verify(r => r.FindByIdAsync(userId.ToString()), Times.Once);
 
             // Ensure AddAsync was called exactly once.
             _mockCommentRepository.Verify(r => r.AddAsync(comment), Times.Once);
 
             // Ensure the mapper's Map was called exactly once with the created comment.
             _mockMapper.Verify(m => m.Map<CommentDTO>(It.IsAny<Comment>()), Times.Once);
+        }
+
+        // Test exception throwing when user is not authenticated
+        [Fact]
+        public async Task VerifyUser_ThrowException_WhenAuthenticatedUserIsNotFound()
+        {
+            var command = new CreateCommentCommand
+            {
+                WorkItemId = Guid.NewGuid(),
+                Text = "Test comment"
+            };
+
+            _mockHttpContextAccessor
+                .Setup(r => r.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier));
+
+            var exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
+                () => _handler.Handle(command, CancellationToken.None)
+            );
+
+            Assert.Equal($"User not authenticated.", exception.Message);
+
+            // Ensure HttpContextAccesor was used exactly once.
+            _mockHttpContextAccessor
+                .Verify(r => r.HttpContext.User.FindFirst(ClaimTypes.NameIdentifier), Times.Once);
         }
 
         // Test exception throwing when work item is not found
@@ -123,11 +162,16 @@ namespace SprintManager.Application.Tests.CommentTests
             var command = new CreateCommentCommand
             {
                 WorkItemId = Guid.NewGuid(),
-                UserId = Guid.NewGuid(),
                 Text = "Test comment"
             };
 
-            // Repository's mock configuration
+            var userId = Guid.NewGuid();
+
+            _mockHttpContextAccessor
+                .Setup(a => a.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier))
+                .Returns(new Claim(ClaimTypes.NameIdentifier, userId.ToString()));
+
             _mockWorkItemRepository.Setup(r => r.GetByIdAsync(command.WorkItemId));
 
             var exception = await Assert.ThrowsAsync<SprintManagerNotFoundException>(
@@ -135,6 +179,11 @@ namespace SprintManager.Application.Tests.CommentTests
             );
 
             Assert.Equal($"Work item with ID {command.WorkItemId} not found.", exception.Message);
+
+            // Ensure HttpContextAccesor was used exactly once.
+            _mockHttpContextAccessor
+                .Verify(a => a.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier), Times.Once);
 
             // Ensure GetByIdAsync was called exactly once.
             _mockWorkItemRepository.Verify(r => r.GetByIdAsync(command.WorkItemId), Times.Once);
@@ -147,23 +196,35 @@ namespace SprintManager.Application.Tests.CommentTests
             var command = new CreateCommentCommand
             {
                 WorkItemId = Guid.NewGuid(),
-                UserId = Guid.NewGuid(),
                 Text = "Test comment"
             };
 
-            // Repository's mock configuration
+            var userId = Guid.NewGuid();
+
+            _mockHttpContextAccessor
+                .Setup(a => a.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier))
+                .Returns(new Claim(ClaimTypes.NameIdentifier, userId.ToString()));
+
             _mockWorkItemRepository.Setup(r => r.GetByIdAsync(command.WorkItemId)).ReturnsAsync(new WorkItem());
-            _mockUserRepository.Setup(r => r.GetByIdAsync(command.UserId));
+            _mockUserManager.Setup(r => r.FindByIdAsync(userId.ToString()));
 
             var exception = await Assert.ThrowsAsync<SprintManagerNotFoundException>(
                 () => _handler.Handle(command, CancellationToken.None)
             );
 
-            Assert.Equal($"User with ID {command.UserId} not found.", exception.Message);
+            Assert.Equal($"User with ID {userId} not found.", exception.Message);
+
+            // Ensure HttpContextAccessor was called exactly once.
+            _mockHttpContextAccessor
+                .Verify(a => a.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier), Times.Once);
 
             // Ensure GetByIdAsync was called exactly once.
             _mockWorkItemRepository.Verify(r => r.GetByIdAsync(command.WorkItemId), Times.Once);
-            _mockUserRepository.Verify(r => r.GetByIdAsync(command.UserId), Times.Once);
+
+            // Ensure FindByIdAsync was called exactly once.
+            _mockUserManager.Verify(r => r.FindByIdAsync(userId.ToString()), Times.Once);
         }
     }
 }

--- a/SprintManager.Application.Tests/CommentTests/DeleteCommentHandlerTests.cs
+++ b/SprintManager.Application.Tests/CommentTests/DeleteCommentHandlerTests.cs
@@ -1,24 +1,31 @@
-﻿using Moq;
+﻿using Microsoft.AspNetCore.Http;
+using Moq;
 using SprintManager.Application.Commands.Comments;
 using SprintManager.Application.Handlers.Comments;
 using SprintManager.Application.Interfaces;
 using SprintManager.Domain.Entities;
 using SprintManager.Exceptions.ExceptionsBase;
+using System.Security.Claims;
 
 namespace SprintManager.Application.Tests.CommentTests
 {
     public class DeleteCommentHandlerTests
     {
+        private readonly Mock<IHttpContextAccessor> _mockHttpContextAccessor;
         private readonly Mock<ICommentRepository> _mockCommentRepository;
         private readonly DeleteCommentHandler _handler;
 
         public DeleteCommentHandlerTests() 
         {
             // Initialize mock for each test
+            _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
             _mockCommentRepository = new Mock<ICommentRepository>();
 
             // Initialize handler injecting the mock
-            _handler = new DeleteCommentHandler(_mockCommentRepository.Object);
+            _handler = new DeleteCommentHandler(
+                _mockHttpContextAccessor.Object,
+                _mockCommentRepository.Object
+            );
         }
 
         // Test handler
@@ -30,19 +37,54 @@ namespace SprintManager.Application.Tests.CommentTests
                 Id = Guid.NewGuid(),
             };
 
-            var comment = new Comment(Guid.NewGuid(), Guid.NewGuid(), "Test comment");
+            var userId = Guid.NewGuid();
 
-            // Repository's mock configuration
+            var comment = new Comment(Guid.NewGuid(), userId, "Test comment");
+
+            _mockHttpContextAccessor
+                .Setup(a => a.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier))
+                .Returns(new Claim(ClaimTypes.NameIdentifier, userId.ToString()));
+
             _mockCommentRepository.Setup(r => r.GetByIdAsync(command.Id)).ReturnsAsync(comment);
             _mockCommentRepository.Setup(r => r.DeleteAsync(comment));
 
             await _handler.Handle(command, CancellationToken.None);
+
+            // Ensure HttpContextAccesor was used exactly once.
+            _mockHttpContextAccessor
+                .Verify(a => a.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier), Times.Once);
 
             // Ensure GetByIdAsync was called exactly once with the correct ID.
             _mockCommentRepository.Verify(r => r.GetByIdAsync(command.Id), Times.Once);
 
             // Ensure DeleteAsync was called exactly once.
             _mockCommentRepository.Verify(r => r.DeleteAsync(comment), Times.Once);
+        }
+
+        // Test exception throwing when user is not authenticated
+        [Fact]
+        public async Task VerifyUser_ThrowException_WhenAuthenticatedUserIsNotFound()
+        {
+            var command = new DeleteCommentCommand
+            {
+                Id = Guid.NewGuid(),
+            };
+
+            _mockHttpContextAccessor
+                .Setup(r => r.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier));
+
+            var exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
+                () => _handler.Handle(command, CancellationToken.None)
+            );
+
+            Assert.Equal($"User not authenticated.", exception.Message);
+
+            // Ensure HttpContextAccesor was used exactly once.
+            _mockHttpContextAccessor
+                .Verify(r => r.HttpContext.User.FindFirst(ClaimTypes.NameIdentifier), Times.Once);
         }
 
         // Test exception throwing when comment is not found
@@ -54,7 +96,13 @@ namespace SprintManager.Application.Tests.CommentTests
                 Id = Guid.NewGuid(),
             };
 
-            // Repository's mock configuration
+            var userId = Guid.NewGuid();
+
+            _mockHttpContextAccessor
+                .Setup(a => a.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier))
+                .Returns(new Claim(ClaimTypes.NameIdentifier, userId.ToString()));
+
             _mockCommentRepository.Setup(r => r.GetByIdAsync(command.Id));
 
             var exception = await Assert.ThrowsAsync<SprintManagerNotFoundException>(
@@ -62,6 +110,44 @@ namespace SprintManager.Application.Tests.CommentTests
             );
 
             Assert.Equal($"Comment with ID {command.Id} not found.", exception.Message);
+
+            // Ensure HttpContextAccesor was used exactly once.
+            _mockHttpContextAccessor
+                .Verify(a => a.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier), Times.Once);
+
+            // Ensure GetByIdAsync was called exactly once.
+            _mockCommentRepository.Verify(r => r.GetByIdAsync(command.Id), Times.Once);
+        }
+
+        // Test exception throwing when comment was not made by authenticated user
+        [Fact]
+        public async Task VerifyComment_ThrowsException_WhenCommentWasNotMadeByAuthenticatedUser()
+        {
+            var command = new DeleteCommentCommand
+            {
+                Id = Guid.NewGuid(),
+            };
+
+            var comment = new Comment(Guid.NewGuid(), Guid.NewGuid(), "Test comment");
+
+            _mockHttpContextAccessor
+                .Setup(a => a.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier))
+                .Returns(new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()));
+
+            _mockCommentRepository.Setup(r => r.GetByIdAsync(command.Id)).ReturnsAsync(comment);
+
+            var exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
+                () => _handler.Handle(command, CancellationToken.None)
+            );
+
+            Assert.Equal($"You can't delete comments made by other users.", exception.Message);
+
+            // Ensure HttpContextAccesor was used exactly once.
+            _mockHttpContextAccessor
+                .Verify(a => a.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier), Times.Once);
 
             // Ensure GetByIdAsync was called exactly once.
             _mockCommentRepository.Verify(r => r.GetByIdAsync(command.Id), Times.Once);

--- a/SprintManager.Application.Tests/CommentTests/UpdateCommentHandlerTests.cs
+++ b/SprintManager.Application.Tests/CommentTests/UpdateCommentHandlerTests.cs
@@ -55,7 +55,6 @@ namespace SprintManager.Application.Tests.CommentTests
                 CreationDate = comment.CreationDate
             };
 
-            // Repository's Mock configuration
             _mockHttpContextAccessor
                 .Setup(a => a.HttpContext.User
                 .FindFirst(ClaimTypes.NameIdentifier))
@@ -141,6 +140,40 @@ namespace SprintManager.Application.Tests.CommentTests
             );
 
             Assert.Equal($"Comment with ID {command?.Id} not found.", exception.Message);
+
+            // Ensure HttpContextAccesor was used exactly once.
+            _mockHttpContextAccessor
+                .Verify(a => a.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier), Times.Once);
+
+            // Ensure GetByIdAsync was called exactly once.
+            _mockCommentRepository.Verify(r => r.GetByIdAsync(command.Id), Times.Once);
+        }
+
+        // Test exception throwing when comment was not made by authenticated user
+        [Fact]
+        public async Task VerifyComment_ThrowsException_WhenCommentWasNotMadeByAuthenticatedUser()
+        {
+            var command = new UpdateCommentCommand
+            {
+                Id = Guid.NewGuid(),
+                Text = "Test comment"
+            };
+
+            var comment = new Comment(Guid.NewGuid(), Guid.NewGuid(), command.Text);
+
+            _mockHttpContextAccessor
+                .Setup(a => a.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier))
+                .Returns(new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()));
+
+            _mockCommentRepository.Setup(r => r.GetByIdAsync(command.Id)).ReturnsAsync(comment);
+
+            var exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
+                () => _handler.Handle(command, CancellationToken.None)
+            );
+
+            Assert.Equal($"You can't update comments made by other users.", exception.Message);
 
             // Ensure HttpContextAccesor was used exactly once.
             _mockHttpContextAccessor

--- a/SprintManager.Application.Tests/CommentTests/UpdateCommentHandlerTests.cs
+++ b/SprintManager.Application.Tests/CommentTests/UpdateCommentHandlerTests.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using Microsoft.AspNetCore.Http;
 using Moq;
 using SprintManager.Application.Commands.Comments;
 using SprintManager.Application.DTOs;
@@ -6,12 +7,13 @@ using SprintManager.Application.Handlers.Comments;
 using SprintManager.Application.Interfaces;
 using SprintManager.Domain.Entities;
 using SprintManager.Exceptions.ExceptionsBase;
-using System.Xml.Linq;
+using System.Security.Claims;
 
 namespace SprintManager.Application.Tests.CommentTests
 {
     public class UpdateCommentHandlerTests
     {
+        private readonly Mock<IHttpContextAccessor> _mockHttpContextAccessor;
         private readonly Mock<ICommentRepository> _mockCommentRepository;
         private readonly Mock<IMapper> _mockMapper;
         private readonly UpdateCommentHandler _handler;
@@ -19,11 +21,16 @@ namespace SprintManager.Application.Tests.CommentTests
         public UpdateCommentHandlerTests()
         {
             // Initialize mocks for each test
+            _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
             _mockCommentRepository = new Mock<ICommentRepository>();
             _mockMapper = new Mock<IMapper>();
 
             // Initialize handler injecting the mocks
-            _handler = new UpdateCommentHandler(_mockCommentRepository.Object, _mockMapper.Object);
+            _handler = new UpdateCommentHandler(
+                _mockHttpContextAccessor.Object,
+                _mockCommentRepository.Object, 
+                _mockMapper.Object
+            );
         }
 
         // Test handler
@@ -36,7 +43,9 @@ namespace SprintManager.Application.Tests.CommentTests
                 Text = "Test comment"
             };
 
-            var comment = new Comment(Guid.NewGuid(), Guid.NewGuid(), command.Text);
+            var userId = Guid.NewGuid();
+
+            var comment = new Comment(Guid.NewGuid(), userId, command.Text);
             var commentDTO = new CommentDTO
             {
                 Id = comment.Id,
@@ -47,6 +56,11 @@ namespace SprintManager.Application.Tests.CommentTests
             };
 
             // Repository's Mock configuration
+            _mockHttpContextAccessor
+                .Setup(a => a.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier))
+                .Returns(new Claim(ClaimTypes.NameIdentifier, userId.ToString()));
+
             _mockCommentRepository.Setup(r => r.GetByIdAsync(command.Id)).ReturnsAsync(comment);
             _mockCommentRepository.Setup(r => r.UpdateAsync(comment));
 
@@ -61,6 +75,11 @@ namespace SprintManager.Application.Tests.CommentTests
             Assert.Equal(commentDTO.Text, result.Text);
             Assert.Equal(commentDTO.CreationDate, result.CreationDate);
 
+            // Ensure HttpContextAccesor was used exactly once.
+            _mockHttpContextAccessor
+                .Verify(a => a.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier), Times.Once);
+
             // Ensure GetByIdAsync was called exactly once with the correct ID.
             _mockCommentRepository.Verify(r => r.GetByIdAsync(command.Id), Times.Once);
 
@@ -69,6 +88,31 @@ namespace SprintManager.Application.Tests.CommentTests
 
             // Ensure the mapper's Map was called exactly once with the modified comment.
             _mockMapper.Verify(m => m.Map<CommentDTO>(comment), Times.Once);
+        }
+
+        // Test exception throwing when user is not authenticated
+        [Fact]
+        public async Task VerifyUser_ThrowException_WhenAuthenticatedUserIsNotFound()
+        {
+            var command = new UpdateCommentCommand
+            {
+                Id = Guid.NewGuid(),
+                Text = "Test comment"
+            };
+
+            _mockHttpContextAccessor
+                .Setup(r => r.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier));
+
+            var exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
+                () => _handler.Handle(command, CancellationToken.None)
+            );
+
+            Assert.Equal($"User not authenticated.", exception.Message);
+
+            // Ensure HttpContextAccesor was used exactly once.
+            _mockHttpContextAccessor
+                .Verify(r => r.HttpContext.User.FindFirst(ClaimTypes.NameIdentifier), Times.Once);
         }
 
         // Test exception throwing when work item is not found
@@ -81,6 +125,14 @@ namespace SprintManager.Application.Tests.CommentTests
                 Text = "Test comment"
             };
 
+            var userId = Guid.NewGuid();
+
+            // Repository's Mock configuration
+            _mockHttpContextAccessor
+                .Setup(a => a.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier))
+                .Returns(new Claim(ClaimTypes.NameIdentifier, userId.ToString()));
+
             // Repository's Mock configuration
             _mockCommentRepository.Setup(r => r.GetByIdAsync(command.Id));
 
@@ -89,6 +141,11 @@ namespace SprintManager.Application.Tests.CommentTests
             );
 
             Assert.Equal($"Comment with ID {command?.Id} not found.", exception.Message);
+
+            // Ensure HttpContextAccesor was used exactly once.
+            _mockHttpContextAccessor
+                .Verify(a => a.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier), Times.Once);
 
             // Ensure GetByIdAsync was called exactly once.
             _mockCommentRepository.Verify(r => r.GetByIdAsync(command.Id), Times.Once);

--- a/SprintManager.Application/Commands/Comments/CreateCommentCommand.cs
+++ b/SprintManager.Application/Commands/Comments/CreateCommentCommand.cs
@@ -6,7 +6,6 @@ namespace SprintManager.Application.Commands.Comments
     public class CreateCommentCommand : IRequest<CommentDTO>
     {
         public Guid WorkItemId { get; set; }
-        public Guid UserId { get; set; }
         public string Text { get; set; }
     }
 }

--- a/SprintManager.Application/Handlers/Comments/CreateCommentHandler.cs
+++ b/SprintManager.Application/Handlers/Comments/CreateCommentHandler.cs
@@ -1,42 +1,54 @@
 ﻿using AutoMapper;
 using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
 using SprintManager.Application.Commands.Comments;
 using SprintManager.Application.DTOs;
 using SprintManager.Application.Interfaces;
 using SprintManager.Domain.Entities;
 using SprintManager.Exceptions.ExceptionsBase;
+using System.Security.Claims;
 
 namespace SprintManager.Application.Handlers.Comments
 {
     public class CreateCommentHandler : IRequestHandler<CreateCommentCommand, CommentDTO>
     {
+        private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly ICommentRepository _commentRepository;
         private readonly IWorkItemRepository _workItemRepository;
-        private readonly IUserRepository _userRepository;
+        private readonly UserManager<User> _userManager;
         private readonly IMapper _mapper;
 
         public CreateCommentHandler(
+            IHttpContextAccessor httpContextAccessor,
             ICommentRepository commentRepository, 
             IWorkItemRepository workItemRepository,
-            IUserRepository userRepository,
+            UserManager<User> userManager,
             IMapper mapper
         )
         {
+            _httpContextAccessor = httpContextAccessor;
             _commentRepository = commentRepository;
             _workItemRepository = workItemRepository;
-            _userRepository = userRepository;
+            _userManager = userManager;
             _mapper = mapper;
         }
 
         public async Task<CommentDTO> Handle(CreateCommentCommand request, CancellationToken cancellationToken)
         {
+            var userIdClaim = _httpContextAccessor.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+            if (string.IsNullOrEmpty(userIdClaim) || !Guid.TryParse(userIdClaim, out var userId))
+                throw new UnauthorizedAccessException("User not authenticated.");
+
             var workItem = await _workItemRepository.GetByIdAsync(request.WorkItemId);
-            var user = await _userRepository.GetByIdAsync(request.UserId);
+            var user = await _userManager.FindByIdAsync(userId.ToString());
 
             if (workItem == null) throw new SprintManagerNotFoundException($"Work item with ID {request.WorkItemId} not found.");
-            if (user == null) throw new SprintManagerNotFoundException($"User with ID {request.UserId} not found.");
+            if (user == null) throw new SprintManagerNotFoundException($"User with ID {userId} not found.");
 
-            var comment = new Comment(request.WorkItemId, request.UserId, request.Text);
+            var comment = new Comment(request.WorkItemId, userId, request.Text);
 
             await _commentRepository.AddAsync(comment);
 

--- a/SprintManager.Application/Handlers/Comments/DeleteCommentHandler.cs
+++ b/SprintManager.Application/Handlers/Comments/DeleteCommentHandler.cs
@@ -1,24 +1,38 @@
 ﻿using MediatR;
+using Microsoft.AspNetCore.Http;
 using SprintManager.Application.Commands.Comments;
 using SprintManager.Application.Interfaces;
 using SprintManager.Exceptions.ExceptionsBase;
+using System.Security.Claims;
 
 namespace SprintManager.Application.Handlers.Comments
 {
     public class DeleteCommentHandler : IRequestHandler<DeleteCommentCommand>
     {
+        private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly ICommentRepository _commentRepository;
 
-        public DeleteCommentHandler(ICommentRepository commentRepository)
+        public DeleteCommentHandler(
+            IHttpContextAccessor httpContextAccessor, 
+            ICommentRepository commentRepository
+        )
         {
+            _httpContextAccessor = httpContextAccessor;
             _commentRepository = commentRepository;
         }
 
         public async Task Handle(DeleteCommentCommand request, CancellationToken cancellationToken)
         {
+            var userIdClaim = _httpContextAccessor.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+            if (string.IsNullOrEmpty(userIdClaim) || !Guid.TryParse(userIdClaim, out var userId))
+                throw new UnauthorizedAccessException("User not authenticated.");
+
             var comment = await _commentRepository.GetByIdAsync(request.Id);
 
             if (comment == null) throw new SprintManagerNotFoundException($"Comment with ID {request?.Id} not found.");
+            if (comment.UserId != userId) throw new UnauthorizedAccessException($"You can't delete comments made by other users.");
 
             await _commentRepository.DeleteAsync(comment);
         }

--- a/SprintManager.Application/Handlers/Comments/UpdateCommentHandler.cs
+++ b/SprintManager.Application/Handlers/Comments/UpdateCommentHandler.cs
@@ -1,28 +1,43 @@
 ﻿using AutoMapper;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using SprintManager.Application.Commands.Comments;
 using SprintManager.Application.DTOs;
 using SprintManager.Application.Interfaces;
 using SprintManager.Exceptions.ExceptionsBase;
+using System.Security.Claims;
 
 namespace SprintManager.Application.Handlers.Comments
 {
     public class UpdateCommentHandler : IRequestHandler<UpdateCommentCommand, CommentDTO>
     {
+        private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly ICommentRepository _commentRepository;
         private readonly IMapper _mapper;
 
-        public UpdateCommentHandler(ICommentRepository commentRepository, IMapper mapper)
+        public UpdateCommentHandler(
+            IHttpContextAccessor httpContextAccessor,
+            ICommentRepository commentRepository, 
+            IMapper mapper
+        )
         {
+            _httpContextAccessor = httpContextAccessor;
             _commentRepository = commentRepository;
             _mapper = mapper;
         }
 
         public async Task<CommentDTO> Handle(UpdateCommentCommand request, CancellationToken cancellationToken)
         {
+            var userIdClaim = _httpContextAccessor.HttpContext.User
+                .FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+            if (string.IsNullOrEmpty(userIdClaim) || !Guid.TryParse(userIdClaim, out var userId))
+                throw new UnauthorizedAccessException("User not authenticated.");
+
             var comment = await _commentRepository.GetByIdAsync(request.Id);
 
             if (comment == null) throw new SprintManagerNotFoundException($"Comment with ID {request?.Id} not found.");
+            if (comment.UserId != userId) throw new UnauthorizedAccessException($"You can't update comments made by other users.");
 
             comment.SetText(request.Text);
 


### PR DESCRIPTION
- Set "userId" property as the authenticated user's id while creating a comment;
- Allow authenticated user to only edit comments made by him;
- Allow authenticated user to only delete comments made by him.